### PR TITLE
feat: add external metadata integration for enhanced music discovery

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,7 @@ SPOTIFY_REDIRECT_URI=http://127.0.0.1:8080/callback
 LASTFM_API_KEY=your_lastfm_api_key_here
 
 # Note: MusicBrainz API requires no API key but has rate limits (1 request/second)
+
+# External API Configuration (Optional)
+# Maximum number of tracks/artists to enhance with external metadata per search
+EXTERNAL_API_CALL_LIMIT=3

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# Spotify API Configuration (Required)
+SPOTIFY_CLIENT_ID=your_spotify_client_id_here
+SPOTIFY_CLIENT_SECRET=your_spotify_client_secret_here
+SPOTIFY_REDIRECT_URI=http://127.0.0.1:8080/callback
+
+# Last.fm API Configuration (Optional - for enhanced music discovery)
+# Get your API key from: https://www.last.fm/api/account/create
+LASTFM_API_KEY=your_lastfm_api_key_here
+
+# Note: MusicBrainz API requires no API key but has rate limits (1 request/second)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ A Model Context Protocol (MCP) server that connects Claude to Spotify, allowing 
 
 - **Playback Control**: Play, pause, skip tracks, and control volume
 - **Music Discovery**: Search for tracks, albums, artists, and playlists
+- **Enhanced Search**: Combines Spotify data with external metadata from Last.fm and MusicBrainz
+- **Similar Artists**: Find similar artists using Last.fm's collaborative filtering
+- **Rich Metadata**: Genre tags, artist biographies, detailed music relationships, and community data
 - **Queue Management**: Add tracks to your queue and view what's coming up
 - **Playlist Management**: Create, modify, and manage your playlists
 - **Music Information**: Get detailed info about any track, album, or artist
@@ -19,6 +22,15 @@ A Model Context Protocol (MCP) server that connects Claude to Spotify, allowing 
 2. Create a new app
 3. Set the redirect URI to: `http://127.0.0.1:8080/callback`
 4. Note your **Client ID** and **Client Secret**
+
+### 1.5. Optional: Get Last.fm API Key (for Enhanced Features)
+
+For enhanced music discovery features:
+1. Go to [Last.fm API account creation](https://www.last.fm/api/account/create)
+2. Create an API account
+3. Note your **API Key**
+
+*Note: Enhanced features will work without Last.fm API key, but with limited external metadata.*
 
 ### 2. Install the Server
 
@@ -48,7 +60,8 @@ Add this to your Claude Desktop config file:
       "env": {
         "SPOTIFY_CLIENT_ID": "your_client_id_here",
         "SPOTIFY_CLIENT_SECRET": "your_client_secret_here",
-        "SPOTIFY_REDIRECT_URI": "http://127.0.0.1:8080/callback"
+        "SPOTIFY_REDIRECT_URI": "http://127.0.0.1:8080/callback",
+        "LASTFM_API_KEY": "your_lastfm_api_key_here"
       }
     }
   }
@@ -70,6 +83,12 @@ Claude: [Searches for jazz, starts playing]
 
 You: "What's currently playing?"
 Claude: [Shows current track info]
+
+You: "Find me artists similar to Radiohead"
+Claude: [Uses Last.fm data to find similar artists with match scores]
+
+You: "Do an enhanced search for 'Bohemian Rhapsody'"
+Claude: [Combines Spotify data with Last.fm genre tags, MusicBrainz metadata, and additional context]
 
 You: "Add this to my favorites playlist"
 Claude: [Adds current track to specified playlist]
@@ -122,10 +141,18 @@ The server automatically handles all Spotify operations through natural conversa
 
 - Control playback (play, pause, skip, volume)
 - Search for any music content
+- **Enhanced search** with external metadata (Last.fm + MusicBrainz)
+- **Find similar artists** using collaborative filtering
 - Manage your queue
 - Work with playlists
 - Get information about tracks/artists/albums
 - Check what's currently playing
+
+### New Enhanced Features
+
+- **Enhanced Search**: Combines Spotify results with genre tags, artist biographies, and detailed music relationships
+- **Similar Artists**: Find artists similar to your favorites using Last.fm's collaborative filtering data
+- **Rich Metadata**: Additional context including community tags, listening statistics, and music database information
 
 ## 🔐 Privacy & Security
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,8 @@ build-backend = "hatchling.build"
 
 [dependency-groups]
 dev = [
+    "pytest>=7.0.0",
+    "pytest-asyncio>=0.21.0",
 ]
 
 [tool.uv.sources]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
  "mcp==1.3.0",
  "python-dotenv>=1.0.1",
  "spotipy==2.24.0",
+ "requests>=2.31.0",
 ]
 [[project.authors]]
 name = "Varun Srivastava"

--- a/src/spotify_mcp/external_metadata.py
+++ b/src/spotify_mcp/external_metadata.py
@@ -1,0 +1,265 @@
+"""
+External metadata sources for enhanced music discovery.
+Integrates with Last.fm and MusicBrainz APIs to provide additional music metadata.
+"""
+
+import logging
+import os
+import time
+from typing import Dict, List, Optional, Any
+from urllib.parse import quote_plus
+
+import requests
+from dotenv import load_dotenv
+
+load_dotenv()
+
+LASTFM_API_KEY = os.getenv("LASTFM_API_KEY")
+LASTFM_BASE_URL = "https://ws.audioscrobbler.com/2.0/"
+MUSICBRAINZ_BASE_URL = "https://musicbrainz.org/ws/2/"
+
+# Rate limiting for MusicBrainz (1 request per second)
+_last_musicbrainz_request = 0
+MUSICBRAINZ_RATE_LIMIT = 1.0
+
+
+class ExternalMetadataClient:
+    """Client for fetching metadata from external sources like Last.fm and MusicBrainz."""
+    
+    def __init__(self, logger: logging.Logger):
+        self.logger = logger
+        self.session = requests.Session()
+        self.session.headers.update({
+            'User-Agent': 'spotify-mcp/1.0 (https://github.com/omniwaifu/spotify-mcp)'
+        })
+    
+    def get_enhanced_track_info(self, artist: str, track: str) -> Dict[str, Any]:
+        """Get enhanced track information from multiple sources."""
+        enhanced_info = {
+            'artist': artist,
+            'track': track,
+            'lastfm_data': None,
+            'musicbrainz_data': None
+        }
+        
+        # Get Last.fm data
+        if LASTFM_API_KEY:
+            try:
+                enhanced_info['lastfm_data'] = self._get_lastfm_track_info(artist, track)
+            except Exception as e:
+                self.logger.error(f"Error fetching Last.fm track info: {e}")
+        
+        # Get MusicBrainz data
+        try:
+            enhanced_info['musicbrainz_data'] = self._get_musicbrainz_track_info(artist, track)
+        except Exception as e:
+            self.logger.error(f"Error fetching MusicBrainz track info: {e}")
+        
+        return enhanced_info
+    
+    def get_enhanced_artist_info(self, artist: str) -> Dict[str, Any]:
+        """Get enhanced artist information from multiple sources."""
+        enhanced_info = {
+            'artist': artist,
+            'lastfm_data': None,
+            'musicbrainz_data': None
+        }
+        
+        # Get Last.fm data
+        if LASTFM_API_KEY:
+            try:
+                enhanced_info['lastfm_data'] = self._get_lastfm_artist_info(artist)
+            except Exception as e:
+                self.logger.error(f"Error fetching Last.fm artist info: {e}")
+        
+        # Get MusicBrainz data  
+        try:
+            enhanced_info['musicbrainz_data'] = self._get_musicbrainz_artist_info(artist)
+        except Exception as e:
+            self.logger.error(f"Error fetching MusicBrainz artist info: {e}")
+        
+        return enhanced_info
+    
+    def get_similar_artists(self, artist: str, limit: int = 10) -> List[Dict[str, Any]]:
+        """Get similar artists from Last.fm."""
+        if not LASTFM_API_KEY:
+            self.logger.warning("Last.fm API key not configured, cannot get similar artists")
+            return []
+        
+        try:
+            params = {
+                'method': 'artist.getsimilar',
+                'artist': artist,
+                'api_key': LASTFM_API_KEY,
+                'format': 'json',
+                'limit': limit
+            }
+            
+            response = self.session.get(LASTFM_BASE_URL, params=params)
+            response.raise_for_status()
+            data = response.json()
+            
+            if 'similarartists' in data and 'artist' in data['similarartists']:
+                similar = []
+                for similar_artist in data['similarartists']['artist']:
+                    similar.append({
+                        'name': similar_artist.get('name'),
+                        'match_score': float(similar_artist.get('match', 0)),
+                        'url': similar_artist.get('url'),
+                        'image': similar_artist.get('image', [{}])[-1].get('#text') if similar_artist.get('image') else None
+                    })
+                return similar
+            
+            return []
+        except Exception as e:
+            self.logger.error(f"Error getting similar artists: {e}")
+            return []
+    
+    def _get_lastfm_track_info(self, artist: str, track: str) -> Optional[Dict[str, Any]]:
+        """Get track information from Last.fm."""
+        params = {
+            'method': 'track.getinfo',
+            'api_key': LASTFM_API_KEY,
+            'artist': artist,
+            'track': track,
+            'format': 'json'
+        }
+        
+        response = self.session.get(LASTFM_BASE_URL, params=params)
+        response.raise_for_status()
+        data = response.json()
+        
+        if 'track' in data:
+            track_data = data['track']
+            return {
+                'name': track_data.get('name'),
+                'artist': track_data.get('artist', {}).get('name'),
+                'album': track_data.get('album', {}).get('title'),
+                'duration': track_data.get('duration'),
+                'listeners': int(track_data.get('listeners', 0)),
+                'playcount': int(track_data.get('playcount', 0)),
+                'tags': [tag['name'] for tag in track_data.get('toptags', {}).get('tag', [])],
+                'url': track_data.get('url'),
+                'wiki': track_data.get('wiki', {}).get('summary')
+            }
+        
+        return None
+    
+    def _get_lastfm_artist_info(self, artist: str) -> Optional[Dict[str, Any]]:
+        """Get artist information from Last.fm."""
+        params = {
+            'method': 'artist.getinfo',
+            'api_key': LASTFM_API_KEY,
+            'artist': artist,
+            'format': 'json'
+        }
+        
+        response = self.session.get(LASTFM_BASE_URL, params=params)
+        response.raise_for_status()
+        data = response.json()
+        
+        if 'artist' in data:
+            artist_data = data['artist']
+            return {
+                'name': artist_data.get('name'),
+                'listeners': int(artist_data.get('stats', {}).get('listeners', 0)),
+                'playcount': int(artist_data.get('stats', {}).get('playcount', 0)),
+                'tags': [tag['name'] for tag in artist_data.get('tags', {}).get('tag', [])],
+                'url': artist_data.get('url'),
+                'bio': artist_data.get('bio', {}).get('summary'),
+                'image': artist_data.get('image', [{}])[-1].get('#text') if artist_data.get('image') else None
+            }
+        
+        return None
+    
+    def _get_musicbrainz_track_info(self, artist: str, track: str) -> Optional[Dict[str, Any]]:
+        """Get track information from MusicBrainz."""
+        self._respect_musicbrainz_rate_limit()
+        
+        # Search for recordings
+        query = f'recording:"{track}" AND artist:"{artist}"'
+        params = {
+            'query': query,
+            'fmt': 'json',
+            'limit': 5
+        }
+        
+        response = self.session.get(f"{MUSICBRAINZ_BASE_URL}recording", params=params)
+        response.raise_for_status()
+        data = response.json()
+        
+        if data.get('recordings'):
+            recording = data['recordings'][0]  # Take the first match
+            return {
+                'id': recording.get('id'),
+                'title': recording.get('title'),
+                'length': recording.get('length'),
+                'disambiguation': recording.get('disambiguation'),
+                'artist_credits': [
+                    {
+                        'name': credit.get('name'),
+                        'artist_id': credit.get('artist', {}).get('id')
+                    }
+                    for credit in recording.get('artist-credit', [])
+                    if isinstance(credit, dict)
+                ],
+                'releases': [
+                    {
+                        'id': release.get('id'),
+                        'title': release.get('title'),
+                        'date': release.get('date')
+                    }
+                    for release in recording.get('releases', [])
+                ],
+                'score': recording.get('score')
+            }
+        
+        return None
+    
+    def _get_musicbrainz_artist_info(self, artist: str) -> Optional[Dict[str, Any]]:
+        """Get artist information from MusicBrainz."""
+        self._respect_musicbrainz_rate_limit()
+        
+        # Search for artists
+        params = {
+            'query': f'artist:"{artist}"',
+            'fmt': 'json',
+            'limit': 5
+        }
+        
+        response = self.session.get(f"{MUSICBRAINZ_BASE_URL}artist", params=params)
+        response.raise_for_status()
+        data = response.json()
+        
+        if data.get('artists'):
+            artist_data = data['artists'][0]  # Take the first match
+            return {
+                'id': artist_data.get('id'),
+                'name': artist_data.get('name'),
+                'sort_name': artist_data.get('sort-name'),
+                'type': artist_data.get('type'),
+                'gender': artist_data.get('gender'),
+                'country': artist_data.get('country'),
+                'disambiguation': artist_data.get('disambiguation'),
+                'begin_area': artist_data.get('begin-area', {}).get('name'),
+                'life_span': {
+                    'begin': artist_data.get('life-span', {}).get('begin'),
+                    'end': artist_data.get('life-span', {}).get('end'),
+                    'ended': artist_data.get('life-span', {}).get('ended')
+                },
+                'score': artist_data.get('score')
+            }
+        
+        return None
+    
+    def _respect_musicbrainz_rate_limit(self):
+        """Ensure we don't exceed MusicBrainz rate limits (1 request per second)."""
+        global _last_musicbrainz_request
+        current_time = time.time()
+        time_since_last = current_time - _last_musicbrainz_request
+        
+        if time_since_last < MUSICBRAINZ_RATE_LIMIT:
+            sleep_time = MUSICBRAINZ_RATE_LIMIT - time_since_last
+            time.sleep(sleep_time)
+        
+        _last_musicbrainz_request = time.time()

--- a/src/spotify_mcp/server.py
+++ b/src/spotify_mcp/server.py
@@ -17,6 +17,7 @@ from spotipy import SpotifyException
 
 from . import spotify_api
 from .utils import normalize_redirect_uri
+from .external_metadata import ExternalMetadataClient
 
 
 def setup_logger():
@@ -35,6 +36,7 @@ logger = setup_logger()
 if spotify_api.REDIRECT_URI:
     spotify_api.REDIRECT_URI = normalize_redirect_uri(spotify_api.REDIRECT_URI)
 spotify_client = spotify_api.Client(logger)
+external_metadata_client = ExternalMetadataClient(logger)
 
 server = Server("spotify-mcp")
 
@@ -144,6 +146,36 @@ class Authentication(ToolModel):
     )
 
 
+class EnhancedSearch(ToolModel):
+    """Enhanced search that combines Spotify data with external metadata sources (Last.fm, MusicBrainz).
+    Provides richer information including similar artists, genre tags, detailed music relationships, and community data.
+    """
+
+    query: str = Field(description="Search query term")
+    search_type: str = Field(
+        default="track",
+        description="Type of search: 'track', 'artist', or 'album'"
+    )
+    include_similar: Optional[bool] = Field(
+        default=True,
+        description="Include similar artists from Last.fm (for artist searches)"
+    )
+    limit: Optional[int] = Field(
+        default=5, 
+        description="Maximum number of results to return"
+    )
+
+
+class SimilarArtists(ToolModel):
+    """Get similar artists based on Last.fm collaborative filtering data."""
+    
+    artist: str = Field(description="Artist name to find similar artists for")
+    limit: Optional[int] = Field(
+        default=10,
+        description="Maximum number of similar artists to return"
+    )
+
+
 @server.list_prompts()
 async def handle_list_prompts() -> list[types.Prompt]:
     return []
@@ -166,6 +198,8 @@ async def handle_list_tools() -> list[types.Tool]:
         GetInfo.as_tool(),
         Playlist.as_tool(),
         Authentication.as_tool(),
+        EnhancedSearch.as_tool(),
+        SimilarArtists.as_tool(),
     ]
     logger.info(f"Available tools: {[tool.name for tool in tools]}")
     return tools
@@ -465,6 +499,86 @@ async def handle_call_tool(
                                 text=f"Unknown authentication action: {action}. Supported actions are: get_auth_url, exchange_code, check_auth.",
                             )
                         ]
+            
+            case "EnhancedSearch":
+                logger.info(f"Enhanced search with arguments: {arguments}")
+                query = arguments.get("query", "")
+                search_type = arguments.get("search_type", "track")
+                include_similar = arguments.get("include_similar", True)
+                limit = arguments.get("limit", 5)
+                
+                # First, get Spotify search results
+                spotify_results = spotify_client.search(
+                    query=query,
+                    qtype=search_type,
+                    limit=limit
+                )
+                
+                enhanced_results = {
+                    "query": query,
+                    "search_type": search_type,
+                    "spotify_results": spotify_results,
+                    "external_metadata": []
+                }
+                
+                # Enhance each result with external metadata
+                if search_type == "track" and spotify_results.get("tracks"):
+                    for track in spotify_results["tracks"][:3]:  # Limit external API calls
+                        try:
+                            enhanced_info = external_metadata_client.get_enhanced_track_info(
+                                track.get("artist", ""), track.get("name", "")
+                            )
+                            enhanced_results["external_metadata"].append(enhanced_info)
+                        except Exception as e:
+                            logger.error(f"Error enhancing track metadata: {e}")
+                
+                elif search_type == "artist" and spotify_results.get("artists"):
+                    for artist in spotify_results["artists"][:3]:  # Limit external API calls
+                        try:
+                            enhanced_info = external_metadata_client.get_enhanced_artist_info(
+                                artist.get("name", "")
+                            )
+                            # Add similar artists if requested
+                            if include_similar:
+                                enhanced_info["similar_artists"] = external_metadata_client.get_similar_artists(
+                                    artist.get("name", ""), limit=5
+                                )
+                            enhanced_results["external_metadata"].append(enhanced_info)
+                        except Exception as e:
+                            logger.error(f"Error enhancing artist metadata: {e}")
+                
+                return [
+                    types.TextContent(
+                        type="text", text=json.dumps(enhanced_results, indent=2)
+                    )
+                ]
+            
+            case "SimilarArtists":
+                logger.info(f"Getting similar artists with arguments: {arguments}")
+                artist = arguments.get("artist", "")
+                limit = arguments.get("limit", 10)
+                
+                if not artist:
+                    return [
+                        types.TextContent(
+                            type="text", text="Artist name is required for similar artists search"
+                        )
+                    ]
+                
+                similar_artists = external_metadata_client.get_similar_artists(artist, limit)
+                
+                result = {
+                    "artist": artist,
+                    "similar_artists": similar_artists,
+                    "count": len(similar_artists)
+                }
+                
+                return [
+                    types.TextContent(
+                        type="text", text=json.dumps(result, indent=2)
+                    )
+                ]
+            
             case _:
                 error_msg = f"Unknown tool: {name}"
                 logger.error(error_msg)

--- a/src/spotify_mcp/server.py
+++ b/src/spotify_mcp/server.py
@@ -19,6 +19,9 @@ from . import spotify_api
 from .utils import normalize_redirect_uri
 from .external_metadata import ExternalMetadataClient
 
+# Configuration constants
+EXTERNAL_API_CALL_LIMIT = int(os.getenv("EXTERNAL_API_CALL_LIMIT", "3"))  # Limit external API calls per search
+
 
 def setup_logger():
     class Logger:
@@ -523,7 +526,7 @@ async def handle_call_tool(
                 
                 # Enhance each result with external metadata
                 if search_type == "track" and spotify_results.get("tracks"):
-                    for track in spotify_results["tracks"][:3]:  # Limit external API calls
+                    for track in spotify_results["tracks"][:EXTERNAL_API_CALL_LIMIT]:
                         try:
                             enhanced_info = external_metadata_client.get_enhanced_track_info(
                                 track.get("artist", ""), track.get("name", "")
@@ -533,7 +536,7 @@ async def handle_call_tool(
                             logger.error(f"Error enhancing track metadata: {e}")
                 
                 elif search_type == "artist" and spotify_results.get("artists"):
-                    for artist in spotify_results["artists"][:3]:  # Limit external API calls
+                    for artist in spotify_results["artists"][:EXTERNAL_API_CALL_LIMIT]:
                         try:
                             enhanced_info = external_metadata_client.get_enhanced_artist_info(
                                 artist.get("name", "")

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# Test package initialization

--- a/tests/test_external_metadata.py
+++ b/tests/test_external_metadata.py
@@ -1,0 +1,169 @@
+"""Tests for external metadata client functionality."""
+
+import pytest
+import logging
+from unittest.mock import Mock, patch, MagicMock
+from src.spotify_mcp.external_metadata import ExternalMetadataClient, RateLimiter
+
+
+class TestRateLimiter:
+    """Test the thread-safe rate limiter."""
+    
+    def test_rate_limiter_initialization(self):
+        """Test rate limiter initializes correctly."""
+        limiter = RateLimiter(rate_limit=1.0)
+        assert limiter._rate_limit == 1.0
+        assert limiter._last_request == 0.0
+        assert limiter._lock is not None
+    
+    @patch('time.time')
+    @patch('time.sleep')
+    def test_rate_limiter_waits_when_needed(self, mock_sleep, mock_time):
+        """Test rate limiter sleeps when requests are too frequent."""
+        # Mock time progression
+        mock_time.side_effect = [0.0, 0.5, 0.5]  # First call, check time, set time
+        
+        limiter = RateLimiter(rate_limit=1.0)
+        limiter._last_request = 0.0
+        limiter.wait_if_needed()
+        
+        # Should sleep for 0.5 seconds (1.0 - 0.5)
+        mock_sleep.assert_called_once_with(0.5)
+    
+    @patch('time.time')
+    @patch('time.sleep')
+    def test_rate_limiter_no_wait_when_not_needed(self, mock_sleep, mock_time):
+        """Test rate limiter doesn't sleep when enough time has passed."""
+        # Mock time progression
+        mock_time.side_effect = [0.0, 2.0, 2.0]  # First call, check time, set time
+        
+        limiter = RateLimiter(rate_limit=1.0)
+        limiter._last_request = 0.0
+        limiter.wait_if_needed()
+        
+        # Should not sleep since 2.0 > 1.0
+        mock_sleep.assert_not_called()
+
+
+class TestExternalMetadataClient:
+    """Test the external metadata client."""
+    
+    @pytest.fixture
+    def mock_logger(self):
+        """Create a mock logger for testing."""
+        return Mock(spec=logging.Logger)
+    
+    @pytest.fixture
+    def client(self, mock_logger):
+        """Create an ExternalMetadataClient for testing."""
+        return ExternalMetadataClient(mock_logger)
+    
+    def test_client_initialization(self, mock_logger):
+        """Test client initializes correctly."""
+        client = ExternalMetadataClient(mock_logger)
+        assert client.logger == mock_logger
+        assert client.session is not None
+        assert 'spotify-mcp' in client.session.headers['User-Agent']
+    
+    def test_get_similar_artists_no_api_key(self, client):
+        """Test get_similar_artists returns empty list when no API key."""
+        with patch('src.spotify_mcp.external_metadata.LASTFM_API_KEY', None):
+            result = client.get_similar_artists("Test Artist")
+            assert result == []
+    
+    @patch('src.spotify_mcp.external_metadata.LASTFM_API_KEY', 'test_key')
+    def test_get_similar_artists_success(self, client):
+        """Test successful similar artists retrieval."""
+        mock_response_data = {
+            'similarartists': {
+                'artist': [
+                    {
+                        'name': 'Similar Artist 1',
+                        'match': '0.85',
+                        'url': 'http://example.com',
+                        'image': [{'#text': 'image_url'}]
+                    }
+                ]
+            }
+        }
+        
+        with patch.object(client.session, 'get') as mock_get:
+            mock_response = Mock()
+            mock_response.json.return_value = mock_response_data
+            mock_response.raise_for_status.return_value = None
+            mock_get.return_value = mock_response
+            
+            result = client.get_similar_artists("Test Artist", limit=5)
+            
+            assert len(result) == 1
+            assert result[0]['name'] == 'Similar Artist 1'
+            assert result[0]['match_score'] == 0.85
+            assert result[0]['image'] == 'image_url'
+    
+    @patch('src.spotify_mcp.external_metadata.LASTFM_API_KEY', 'test_key')
+    def test_get_similar_artists_empty_image_list(self, client):
+        """Test similar artists with empty image list doesn't crash."""
+        mock_response_data = {
+            'similarartists': {
+                'artist': [
+                    {
+                        'name': 'Similar Artist 1',
+                        'match': '0.85',
+                        'url': 'http://example.com',
+                        'image': []  # Empty image list
+                    }
+                ]
+            }
+        }
+        
+        with patch.object(client.session, 'get') as mock_get:
+            mock_response = Mock()
+            mock_response.json.return_value = mock_response_data
+            mock_response.raise_for_status.return_value = None
+            mock_get.return_value = mock_response
+            
+            result = client.get_similar_artists("Test Artist")
+            
+            assert len(result) == 1
+            assert result[0]['image'] is None  # Should be None, not crash
+    
+    def test_get_similar_artists_api_error(self, client):
+        """Test similar artists handles API errors gracefully."""
+        with patch('src.spotify_mcp.external_metadata.LASTFM_API_KEY', 'test_key'):
+            with patch.object(client.session, 'get') as mock_get:
+                mock_get.side_effect = Exception("API Error")
+                
+                result = client.get_similar_artists("Test Artist")
+                
+                assert result == []
+                client.logger.error.assert_called_once()
+    
+    def test_musicbrainz_rate_limiting(self, client):
+        """Test MusicBrainz rate limiting is called."""
+        with patch.object(client, '_respect_musicbrainz_rate_limit') as mock_rate_limit:
+            with patch.object(client.session, 'get') as mock_get:
+                mock_response = Mock()
+                mock_response.json.return_value = {'recordings': []}
+                mock_response.raise_for_status.return_value = None
+                mock_get.return_value = mock_response
+                
+                client._get_musicbrainz_track_info("Artist", "Track")
+                
+                mock_rate_limit.assert_called_once()
+    
+    def test_enhanced_track_info_error_handling(self, client):
+        """Test enhanced track info handles errors gracefully."""
+        with patch.object(client, '_get_lastfm_track_info') as mock_lastfm:
+            with patch.object(client, '_get_musicbrainz_track_info') as mock_mb:
+                mock_lastfm.side_effect = Exception("Last.fm error")
+                mock_mb.side_effect = Exception("MusicBrainz error")
+                
+                result = client.get_enhanced_track_info("Artist", "Track")
+                
+                assert result['artist'] == "Artist"
+                assert result['track'] == "Track"
+                assert result['lastfm_data'] is None
+                assert result['musicbrainz_data'] is None
+                
+                # Should log errors
+                assert client.logger.error.call_count == 2


### PR DESCRIPTION
Implements external metadata sources as requested in issue #2 to provide alternatives to RYM for additional off-Spotify metadata.

## Changes
- Added Last.fm API integration for similar artists and community data
- Added MusicBrainz API integration for detailed music metadata
- Created new MCP tools: EnhancedSearch and SimilarArtists
- Updated documentation with setup instructions
- Maintained backward compatibility

## Benefits
- Better music discovery through collaborative filtering
- Rich metadata including genre tags and artist relationships
- No breaking changes to existing functionality

Generated with [Claude Code](https://claude.ai/code)